### PR TITLE
fix: added sys/sysctl for FreeBSD

### DIFF
--- a/src/sandbox-posix.c
+++ b/src/sandbox-posix.c
@@ -38,6 +38,9 @@
 #include <sys/signal.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#endif
 
 #if defined (HAVE_CLOCK_GETTIME)
 # include <time.h>


### PR DESCRIPTION
Without this header CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME are undeclared on FreeBSD 10.3