### PR TITLE
ci: Fixed path to isdir.py when building as meson subproject.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project('boxfort', 'c',
 prefix    = get_option('prefix')
 
 # Helper scripts
-auxdir  = join_paths(meson.source_root(), 'ci')
+auxdir  = join_paths(meson.current_source_dir(), 'ci')
 isdir   = join_paths(auxdir, 'isdir.py')
 
 python3 = find_program('python3')


### PR DESCRIPTION
Fixes [criterion#327](https://github.com/Snaipe/Criterion/issues/327).