### PR TITLE
meson: Add options to not-build samples and tests.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ project('boxfort', 'c',
 
 # standard install directories
 prefix    = get_option('prefix')
+samples   = get_option('samples')
+tests     = get_option('tests')
 
 # Helper scripts
 auxdir  = join_paths(meson.current_source_dir(), 'ci')
@@ -218,5 +220,11 @@ else
 endif
 
 subdir('src')
-subdir('sample')
-subdir('test')
+
+if samples
+	subdir('sample')
+endif
+
+if tests
+	subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('arena_reopen_shm', type: 'boolean', value: false, description: 'Reopen shared memory file in worker process rather than just inherit a file descriptor')
 option('arena_file_backed', type: 'boolean', value: false, description: 'Use a file in tempfs to store the arena rather than using shm facilities')
+option('samples', type: 'boolean', value: true, description: 'Build samples')
+option('tests', type: 'boolean', value: true, description: 'Build and run tests')


### PR DESCRIPTION
When using boxfort as a subproject, `meson test` runs boxfort's tests. I believe a typical developer developing `their super project` wants to run only own tests, not dependencies' ones.

Thankfully boxfort's tests do not have much of impact, so they at least clutter the view. :)

This PR adds `-Dsamples` and `-Dtests` options to enable/disable, like this:

```sh
meson setup -Dsamples=false -Dtests=false build && cd build && meson test
# Or as a subproject
meson setup -Dboxfort:samples=false -Dboxfort:tests=false build && cd build && meson test
```

See the attached asciinema cast: [boxfort.cast.zip](https://github.com/Snaipe/BoxFort/files/4030878/boxfort.cast.zip)
