### PR TITLE
Search for cram as cram3

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,5 @@
 sh   = find_program('sh', required: false)
-cram = find_program('cram', required: false)
+cram = find_program('cram', 'cram3', required: false)
 if sh.found() and cram.found()
 	env = environment()
 	env.prepend('PATH',


### PR DESCRIPTION
In Debian Bullseye and later cram is called cram3 (as that is the python3
version)