### PR TITLE
FreeBSD sandbox: delivers SIGTERM/SIGKILL when parent exits same

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,7 @@ checks = [
 	{'fn': 'gettimeofday'},
 	{'fn': 'mincore'},
 	{'fn': 'prctl'},
+	{'fn': 'procctl'},
 	{'fn': 'shm_open'},
 	{'fn': 'mach_vm_protect'},
 	{'fn': '__builtin___clear_cache'},
@@ -139,6 +140,7 @@ checks = [
 	},
 
 	{'sym': 'PR_SET_PDEATHSIG',    'header': 'sys/prctl.h'},
+	{'sym': 'PROC_PDEATHSIG_CTL',  'header': 'sys/procctl.h'},
 	{'sym': 'CLOCK_MONOTONIC_RAW', 'header': 'time.h'},
 	{'sym': 'environ',             'header': 'unistd.h'},
 ]

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -49,6 +49,7 @@
 #mesondefine HAVE__R_DEBUG
 #mesondefine HAVE__DYNAMIC
 #mesondefine HAVE_PR_SET_PDEATHSIG
+#mesondefine HAVE_PROC_PDEATHSIG_CTL
 #mesondefine HAVE_CLOCK_GETTIME
 #mesondefine HAVE_CLOCK_MONOTONIC_RAW
 #mesondefine HAVE_GETTIMEOFDAY

--- a/src/sandbox-posix.c
+++ b/src/sandbox-posix.c
@@ -61,6 +61,10 @@
 # include <sys/prctl.h>
 #endif
 
+#if defined (HAVE_PROC_PDEATHSIG_CTL)
+# include <sys/procctl.h>
+#endif
+
 #if defined (__APPLE__)
 # include <mach-o/dyld.h>
 #endif
@@ -808,11 +812,14 @@ int bxfi_exec(bxf_instance **out, bxf_sandbox *sandbox,
         return 0;
     }
 
-#if defined (HAVE_PR_SET_PDEATHSIG)
+#if defined (HAVE_PR_SET_PDEATHSIG) || defined (HAVE_PROC_PDEATHSIG_CTL)
     int pdeathsig = (BXF_DBG_GET_DEBUGGER(sandbox->debug.debugger) && !instance->debug_falls_back_to_suspend)
         ? SIGTERM : SIGKILL;
-
+#if defined (HAVE_PR_SET_PDEATHSIG)
     prctl(PR_SET_PDEATHSIG, pdeathsig);
+#else
+    procctl(P_PID, 0, PROC_PDEATHSIG_CTL, &pdeathsig);
+#endif
 #endif
 
     pid = getpid();


### PR DESCRIPTION
 as Linux.