### PR TITLE
Bypass macOS' max_protection using mach_vm_protect(VM_PROT_COPY)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,7 @@ checks = [
 	{'fn': 'mincore'},
 	{'fn': 'prctl'},
 	{'fn': 'shm_open'},
+	{'fn': 'mach_vm_protect'},
 
 	# some platforms define mincore with an unsigned vector
 	{

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -52,6 +52,7 @@
 #mesondefine HAVE_CLOCK_GETTIME
 #mesondefine HAVE_CLOCK_MONOTONIC_RAW
 #mesondefine HAVE_GETTIMEOFDAY
+#mesondefine HAVE_MACH_VM_PROTECT
 #mesondefine HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
 #mesondefine HAVE_ENVIRON
 #mesondefine HAVE_MINCORE


### PR DESCRIPTION
`max_prot` disallows injecting the BoxFort trampoline into main()'s location.

This PR replaces the `mprotect()` call with `vm_protect(VM_PROT_COPY)`, which gets (COW) a writable page.

https://stackoverflow.com/questions/60654834/using-mprotect-to-make-text-segment-writable-on-macos

Note: `mprotect()` would still work in cases when the library is dynamically linked to the executable.