### PR TITLE
Fix aarch64 trampoline, add Apple silicon support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,7 +43,7 @@ MacOS_task:
 
 FreeBSD_task:
   freebsd_instance:
-    image_family: freebsd-12-0
+    image_family: freebsd-13-0
   setup_script: pkg install -y meson
   <<: *pipeline
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ Alpine (gcc,aarch64)_task:
 
 MacOS_task:
   osx_instance:
-    image: mojave-xcode-10.2
+    image: monterey-xcode-13.2
   setup_script: brew install meson
   <<: *pipeline
 
@@ -58,4 +58,3 @@ Windows_task:
     pip install meson
   ninja-setup_script: choco install -y --no-progress ninja
   <<: *pipeline
-

--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,7 @@ checks = [
 	{'fn': 'prctl'},
 	{'fn': 'shm_open'},
 	{'fn': 'mach_vm_protect'},
+	{'fn': '__builtin___clear_cache'},
 
 	# some platforms define mincore with an unsigned vector
 	{

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -53,6 +53,7 @@
 #mesondefine HAVE_CLOCK_MONOTONIC_RAW
 #mesondefine HAVE_GETTIMEOFDAY
 #mesondefine HAVE_MACH_VM_PROTECT
+#mesondefine HAVE___BUILTIN___CLEAR_CACHE
 #mesondefine HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE_NP
 #mesondefine HAVE_ENVIRON
 #mesondefine HAVE_MINCORE

--- a/src/exe-elf.c
+++ b/src/exe-elf.c
@@ -226,6 +226,8 @@ int bxfi_exe_patch_main(bxfi_exe_fn *new_main)
     mprotect(base, len, PROT_READ | PROT_WRITE | PROT_EXEC);
     memcpy(nonstd (void *) addr, opcodes, sizeof (opcodes));
     mprotect(base, len, PROT_READ | PROT_EXEC);
+    bxfi_exe_clear_cache(addr, sizeof(opcodes));
+
     return 0;
 }
 

--- a/src/exe-mach-o.c
+++ b/src/exe-mach-o.c
@@ -129,7 +129,7 @@ int bxfi_exe_patch_main(bxfi_exe_fn *new_main)
     uintptr_t offset = (uintptr_t) addr - (uintptr_t) base;
     size_t len = align2_up(offset + sizeof (opcodes), PAGE_SIZE);
 
-    mem_protect(base, len, PROT_READ | PROT_WRITE | PROT_EXEC);
+    mem_protect(base, len, PROT_READ | PROT_WRITE);
     memcpy(nonstd (void *) addr, opcodes, sizeof (opcodes));
     mem_protect(base, len, PROT_READ | PROT_EXEC);
     bxfi_exe_clear_cache(addr, sizeof(opcodes));

--- a/src/exe-mach-o.c
+++ b/src/exe-mach-o.c
@@ -132,6 +132,8 @@ int bxfi_exe_patch_main(bxfi_exe_fn *new_main)
     mem_protect(base, len, PROT_READ | PROT_WRITE | PROT_EXEC);
     memcpy(nonstd (void *) addr, opcodes, sizeof (opcodes));
     mem_protect(base, len, PROT_READ | PROT_EXEC);
+    bxfi_exe_clear_cache(addr, sizeof(opcodes));
+
     return 0;
 }
 

--- a/src/exe-pe.c
+++ b/src/exe-pe.c
@@ -94,6 +94,8 @@ int bxfi_exe_patch_main(bxfi_exe_fn *new_main)
     VirtualProtect(base, len, PAGE_EXECUTE_READWRITE, &old);
     memcpy(nonstd (void *) addr, opcodes, size);
     VirtualProtect(base, len, old, NULL);
+    bxfi_exe_clear_cache(addr, size);
+
     return 0;
 }
 

--- a/src/exe.h
+++ b/src/exe.h
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef PLT_H_
-#define PLT_H_
+#ifndef EXE_H_
+#define EXE_H_
 
 #include <stddef.h>
 
@@ -50,4 +50,4 @@ static inline void bxfi_exe_clear_cache(void *addr, size_t len)
 #endif
 }
 
-#endif /* !PLT_H_ */
+#endif /* !EXE_H_ */

--- a/src/exe.h
+++ b/src/exe.h
@@ -43,4 +43,11 @@ const char *bxfi_lib_name(bxfi_exe_lib lib);
 void bxfi_lib_name_term(const char *str);
 size_t bxfi_exe_get_vmslide(bxfi_exe_lib lib);
 
+static inline void bxfi_exe_clear_cache(void *addr, size_t len)
+{
+#if defined (HAVE___BUILTIN___CLEAR_CACHE)
+    __builtin___clear_cache((char *) addr, (char *) addr + len);
+#endif
+}
+
 #endif /* !PLT_H_ */


### PR DESCRIPTION
BoxFort workers replace their own main function by injecting asm instructions into their original `main()`.

CPU cache lines have to be flushed after modifying executable memory in order to obtain deterministic behavior.

This fixes sandboxing on aarch64, for example: Snaipe/Criterion#312

Note: Currently, `bxfi_exe_clear_cache()` is not implemented for Windows.