### PR TITLE
arena: add workaround for unimplemented mincore() on WSL 1

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -111,6 +111,9 @@ static int page_mapped(void *addr) {
             return 1;
         if (errno == ENOMEM)
             return 0;
+
+        if (errno == ENOSYS || errno == ENOTSUP)
+            return page_mapped_msync(addr);
     }
     bug("mincore(2) returned an unexpected error");
 #else


### PR DESCRIPTION
Windows Subsystem for Linux v1 does not support `mincore()`, but the available Linux distributions on WSL use unmodified libc packages, which export `mincore()`.

In that case, `mincore()` returns ENOSYS.

https://docs.microsoft.com/en-us/windows/wsl/release-notes