### PR TITLE
context: Align object data to machine words

### DIFF
--- a/sample/context.c
+++ b/sample/context.c
@@ -51,6 +51,9 @@ EXPORT int main(void)
     long my_long = 24;
     _assert(!bxf_context_addobject(ctx, "long_id", &my_long, sizeof (my_long)));
 
+    /* Check that my_long is aligned in memory */
+    _assert(((uintptr_t)my_long % sizeof (void *)) == 0);
+
     /* We run the child function with the created context */
     _assert(!bxf_run(child, .inherit.context = ctx));
 

--- a/src/context.h
+++ b/src/context.h
@@ -61,6 +61,7 @@ struct bxfi_ctx_arena {
 struct bxfi_ctx_object {
     enum bxfi_ctx_tag tag;
     size_t namesz;
+    size_t offset;
     char data[];
 };
 


### PR DESCRIPTION
Using BoxFort with AddressSanitizer enabled caused alignment errors as structures are no longer aligned to proper boundaries. This is especially bad for loading pointers.