### PR TITLE
Add 39-bit virtual memory scheme support for riscv64.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,8 @@ if cc.symbols_have_underscore_prefix()
 	mangling = 'leading-underscore'
 endif
 
+memory_addr_bits = 'undefined'
+
 if arch == 'x86'
 	bitness = 32
 elif arch == 'x86_64'
@@ -88,6 +90,9 @@ elif arch == 'aarch64'
 	bitness = 64
 elif arch == 'riscv64'
 	bitness = 64
+	# 39 bit virtual address scheme(sv39) is widely used in riscv64 in 2023
+	# still need to find a stable method to detect address scheme in user mode
+	memory_addr_bits = '39'
 else
 	error('Architecture "@0@" is not supported.'.format(arch))
 endif
@@ -120,6 +125,10 @@ config.set('BXF_ARCH', '"' + arch + '"')
 config.set('BXF_ARCH_@0@'.format(arch.to_upper()), 1)
 config.set('BXF_MANGLING', mangling)
 config.set('BXF_BITS', bitness)
+
+if memory_addr_bits != 'undefined'
+	config.set('BXF_MEM_ADDR_BITS', memory_addr_bits)
+endif
 
 checks = [
 	{'fn': 'clock_gettime'},

--- a/src/arena.c
+++ b/src/arena.c
@@ -54,11 +54,19 @@ static void *mmap_max  = (void *) 0x80000000;
 static intptr_t mmap_off = (intptr_t) 1 << 16;
 static intptr_t mmap_off_mask = 0x3fff;
 #elif BXF_BITS == 64
+# ifndef BXF_MEM_ADDR_BITS
 /* On Linux it seems that you cannot map > 48-bit addresses */
 static void *mmap_base = (void *) 0x200000000000;
 static void *mmap_max  = (void *) 0x7f0000000000;
 static intptr_t mmap_off = (intptr_t) 1 << 24;
 static intptr_t mmap_off_mask = 0x3fffff;
+# elif BXF_MEM_ADDR_BITS == 39
+/* 39-bit virtual memory scheme is used in some riscv64 or amd64 machines */
+static void *mmap_base = (void *) 0x1000000000;
+static void *mmap_max  = (void *) 0x3f00000000;
+static intptr_t mmap_off = (intptr_t) 1 << 20;
+static intptr_t mmap_off_mask = 0x1ffff;
+# endif
 #else
 # error Platform not supported
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -29,6 +29,8 @@
 #mesondefine BXF_MANGLING
 #mesondefine BXF_OS_FAMILY
 
+#mesondefine BXF_MEM_ADDR_BITS
+
 # ifdef BXF_OS_FAMILY
 #  define BXF_OS_FAMILY_STR #BXF_OS_FAMILY
 # endif


### PR DESCRIPTION
Fixed arena memory allocation faillure on riscv64, see issue #44 .

The allocation assumes 48bit address on linux, but most RISC-V machines use 39bit address by default currently. I tried to add 39bit scheme to `arena.c` and set it to all riscv64 build.

But it may not be a good choice to decide memory address mode at configuration time.
- `satp`  register, which contains address scheme on riscv64, is unreadable in user mode.
- `/proc/cpuinfo` `/proc/sys/vm/pagemap` `/proc/config.gz` could provide the info. But they are not always available on every machine and in cross compilation.

So I set this PR to WIP. I would be appreciated if anyone helps me.